### PR TITLE
feat(Get-NeverSignedInUsers): InactiveDays, ExcludeDisabled parameters and README improvements

### DIFF
--- a/Get-NeverSignedInUsers/Get-NeverSignedInUsers.ps1
+++ b/Get-NeverSignedInUsers/Get-NeverSignedInUsers.ps1
@@ -112,7 +112,7 @@ process {
     #region Filter users with no recorded sign-in activity (or inactive beyond threshold)
     try {
         if ($PSBoundParameters.ContainsKey("InactiveDays")) {
-            $InactiveCutOff = [DateTimeOffset]::UtcNow.AddDays(-1 * $InactiveDays)
+            $InactiveCutOff = [DateTime]::UtcNow.AddDays(-1 * $InactiveDays)
             Write-Verbose -Message "Applying InactiveDays filter: last sign-in before $($InactiveCutOff) or no sign-in recorded."
             $NeverSignedIn = $Users |
                 Where-Object -FilterScript {

--- a/Get-NeverSignedInUsers/Get-NeverSignedInUsers.ps1
+++ b/Get-NeverSignedInUsers/Get-NeverSignedInUsers.ps1
@@ -1,6 +1,6 @@
 <#PSScriptInfo
 
-.VERSION 1.0.0
+.VERSION 1.1.0
 
 .GUID 2b0f2c1d-7d2a-4d0a-9a4e-7b1b5d2f1c6e
 
@@ -41,11 +41,22 @@
     Optional filter: only include users created within the specified number of days.
     Useful to approximate "never signed in" for newly provisioned accounts.
 
+.PARAMETER InactiveDays
+    Optional filter: include users whose last sign-in (interactive or non-interactive) is older
+    than the specified number of days, in addition to users with no recorded sign-in activity.
+    Accepts an integer between 1 and 3650 (e.g. 90 for 90 days).
+
 .EXAMPLE
     Get-NeverSignedInUsers.ps1 -Verbose
 
 .EXAMPLE
     Get-NeverSignedInUsers.ps1 -CreatedWithinDays 30 -ExportCsv "NeverSignedIn.csv" -Verbose
+
+.EXAMPLE
+    Get-NeverSignedInUsers.ps1 -InactiveDays 90 -Verbose
+
+.EXAMPLE
+    Get-NeverSignedInUsers.ps1 -InactiveDays 90 -ExportCsv "InactiveUsers.csv" -Verbose
 
 .LINK
     https://learn.microsoft.com/graph/api/resources/signinactivity
@@ -62,7 +73,12 @@ param (
     [Parameter(Mandatory = $false)]
     [ValidateRange(1, 3650)]
     [Int]
-    $CreatedWithinDays
+    $CreatedWithinDays,
+
+    [Parameter(Mandatory = $false)]
+    [ValidateRange(1, 3650)]
+    [Int]
+    $InactiveDays
 )
 
 begin {
@@ -93,14 +109,29 @@ process {
     }
     #endregion
 
-    #region Filter users with no recorded sign-in activity
+    #region Filter users with no recorded sign-in activity (or inactive beyond threshold)
     try {
-        $NeverSignedIn = $Users |
-            Where-Object -FilterScript {
-                -not $_.SignInActivity -or (
-                    -not $_.SignInActivity.LastSignInDateTime -and -not $_.SignInActivity.LastNonInteractiveSignInDateTime
-                )
-            }
+        if ($PSBoundParameters.ContainsKey("InactiveDays")) {
+            $InactiveCutOff = [DateTimeOffset]::UtcNow.AddDays(-1 * $InactiveDays)
+            Write-Verbose -Message "Applying InactiveDays filter: last sign-in before $($InactiveCutOff) or no sign-in recorded."
+            $NeverSignedIn = $Users |
+                Where-Object -FilterScript {
+                    -not $_.SignInActivity -or (
+                        -not $_.SignInActivity.LastSignInDateTime -and -not $_.SignInActivity.LastNonInteractiveSignInDateTime
+                    ) -or (
+                        ($_.SignInActivity.LastSignInDateTime -and $_.SignInActivity.LastSignInDateTime -lt $InactiveCutOff) -or
+                        ($_.SignInActivity.LastNonInteractiveSignInDateTime -and $_.SignInActivity.LastNonInteractiveSignInDateTime -lt $InactiveCutOff)
+                    )
+                }
+        }
+        else {
+            $NeverSignedIn = $Users |
+                Where-Object -FilterScript {
+                    -not $_.SignInActivity -or (
+                        -not $_.SignInActivity.LastSignInDateTime -and -not $_.SignInActivity.LastNonInteractiveSignInDateTime
+                    )
+                }
+        }
 
         if ($PSBoundParameters.ContainsKey("CreatedWithinDays")) {
             $CutOff = [DateTimeOffset]::UtcNow.AddDays(-1 * $CreatedWithinDays)

--- a/Get-NeverSignedInUsers/Get-NeverSignedInUsers.ps1
+++ b/Get-NeverSignedInUsers/Get-NeverSignedInUsers.ps1
@@ -1,6 +1,6 @@
 <#PSScriptInfo
 
-.VERSION 1.1.0
+.VERSION 1.2.0
 
 .GUID 2b0f2c1d-7d2a-4d0a-9a4e-7b1b5d2f1c6e
 
@@ -46,6 +46,9 @@
     than the specified number of days, in addition to users with no recorded sign-in activity.
     Accepts an integer between 1 and 3650 (e.g. 90 for 90 days).
 
+.PARAMETER ExcludeDisabled
+    Optional switch: exclude users where AccountEnabled is False from the results.
+
 .EXAMPLE
     Get-NeverSignedInUsers.ps1 -Verbose
 
@@ -57,6 +60,9 @@
 
 .EXAMPLE
     Get-NeverSignedInUsers.ps1 -InactiveDays 90 -ExportCsv "InactiveUsers.csv" -Verbose
+
+.EXAMPLE
+    Get-NeverSignedInUsers.ps1 -ExcludeDisabled -Verbose
 
 .LINK
     https://learn.microsoft.com/graph/api/resources/signinactivity
@@ -78,7 +84,11 @@ param (
     [Parameter(Mandatory = $false)]
     [ValidateRange(1, 3650)]
     [Int]
-    $InactiveDays
+    $InactiveDays,
+
+    [Parameter(Mandatory = $false)]
+    [Switch]
+    $ExcludeDisabled
 )
 
 begin {
@@ -137,6 +147,11 @@ process {
             $CutOff = [DateTimeOffset]::UtcNow.AddDays(-1 * $CreatedWithinDays)
             Write-Verbose -Message "Applying CreatedWithinDays filter: created after $($CutOff)."
             $NeverSignedIn = $NeverSignedIn | Where-Object -FilterScript { $_.CreatedDateTime -ge $CutOff }
+        }
+
+        if ($ExcludeDisabled) {
+            Write-Verbose -Message "Applying ExcludeDisabled filter: removing accounts where AccountEnabled is False."
+            $NeverSignedIn = $NeverSignedIn | Where-Object -FilterScript { $_.AccountEnabled -eq $true }
         }
 
         $Result = $NeverSignedIn | Select-Object -Property `

--- a/Get-NeverSignedInUsers/README.md
+++ b/Get-NeverSignedInUsers/README.md
@@ -46,3 +46,9 @@ Find users inactive for a custom number of days and export to CSV:
 ```PowerShell
 ./Get-NeverSignedInUsers.ps1 -InactiveDays 60 -ExportCsv "InactiveUsers.csv" -Verbose
 ```
+
+Exclude disabled accounts from results:
+
+```PowerShell
+./Get-NeverSignedInUsers.ps1 -ExcludeDisabled -Verbose
+```

--- a/Get-NeverSignedInUsers/README.md
+++ b/Get-NeverSignedInUsers/README.md
@@ -20,17 +20,29 @@ Install-Module Microsoft.Graph -Scope CurrentUser -Repository PSGallery -Force
 ## Usage
 
 ```PowerShell
-Get-NeverSignedInUsers.ps1 -Verbose
+./Get-NeverSignedInUsers.ps1 -Verbose
 ```
 
 Export results to CSV:
 
 ```PowerShell
-Get-NeverSignedInUsers.ps1 -ExportCsv "NeverSignedIn.csv" -Verbose
+./Get-NeverSignedInUsers.ps1 -ExportCsv "NeverSignedIn.csv" -Verbose
 ```
 
 Limit to users created within the last 30 days (approximate "never" for new accounts):
 
 ```PowerShell
-Get-NeverSignedInUsers.ps1 -CreatedWithinDays 30 -ExportCsv "NeverSignedIn.csv" -Verbose
+./Get-NeverSignedInUsers.ps1 -CreatedWithinDays 30 -ExportCsv "NeverSignedIn.csv" -Verbose
+```
+
+Find users who have not signed in for 90 days (or have no recorded sign-in activity):
+
+```PowerShell
+./Get-NeverSignedInUsers.ps1 -InactiveDays 90 -Verbose
+```
+
+Find users inactive for a custom number of days and export to CSV:
+
+```PowerShell
+./Get-NeverSignedInUsers.ps1 -InactiveDays 60 -ExportCsv "InactiveUsers.csv" -Verbose
 ```

--- a/Set-BulkUserDetails/README.md
+++ b/Set-BulkUserDetails/README.md
@@ -21,13 +21,13 @@ Install-Module Microsoft.Graph -Scope CurrentUser -Repository PSGallery -Force
 ## Usage
 
 ```PowerShell
-Set-BulkUserDetails.ps1 -CsvFile "UserDetails.csv"
+./Set-BulkUserDetails.ps1 -CsvFile "UserDetails.csv"
 ```
 
 Preview changes without applying them (`-WhatIf`):
 
 ```PowerShell
-Set-BulkUserDetails.ps1 -CsvFile "UserDetails.csv" -WhatIf
+./Set-BulkUserDetails.ps1 -CsvFile "UserDetails.csv" -WhatIf
 ```
 
 ### CSV format

--- a/Set-BulkUserUPN/README.md
+++ b/Set-BulkUserUPN/README.md
@@ -18,5 +18,5 @@ Install-Module Microsoft.Graph -Scope CurrentUser -Repository PSGallery -Force
 ## Usage
 
 ```PowerShell
-Set-BulkUserUPN.ps1 -Domain "example.com" -Verbose
+./Set-BulkUserUPN.ps1 -Domain "example.com" -Verbose
 ```


### PR DESCRIPTION
## Summary

- Add `-InactiveDays` parameter to include users whose last sign-in is older than N days (in addition to users with no recorded sign-in activity)
- Fix type mismatch bug: `LastSignInDateTime` is `System.DateTime` but cutoff was `System.DateTimeOffset`, causing a comparison error
- Add `-ExcludeDisabled` switch to exclude accounts where `AccountEnabled` is `False`
- Add `./` prefix to all script usage examples across READMEs

🤖 Generated with [Claude Code](https://claude.com/claude-code)